### PR TITLE
Fixed names, added `Llama 3.3 70B SpecDec 8k`, and updated `package.json`

### DIFF
--- a/extensions/groq/CHANGELOG.md
+++ b/extensions/groq/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Groq Changelog
 
-## [New Models] - 2024-12-06
-- Added `Llama 3.3 70B`
+## [New Models] - 2024-12-13
+
+- Added `Llama 3.3 70B` and `Llama 3.3 70B SpecDec`
 
 ## [New Models] - 2024-07-26
 
@@ -31,6 +32,5 @@
 ## [New Model] - 2024-03-13
 
 - Added new model `Gemma 7B`
-
 
 ## [Initial Version] - 2024-03-01

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -31,20 +31,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -89,20 +93,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -147,20 +155,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -205,20 +217,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -263,20 +279,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -321,20 +341,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -395,20 +419,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -470,20 +498,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -529,20 +561,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -588,20 +624,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -647,20 +687,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -706,20 +750,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -765,20 +813,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -824,20 +876,24 @@
               "value": "global"
             },
             {
-              "value": "llama-3.1-70b-versatile",
-              "title": "Llama3.1 70B 132k"
+              "value": "llama-3.3-70b-versatile",
+              "title": "Llama 3.3 70B 128k"
+            },
+            {
+              "value": "llama-3.3-70b-specdec",
+              "title": "Llama 3.3 70B SpecDec 8k"
             },
             {
               "value": "llama-3.1-8b-instant",
-              "title": "Llama3.1 8B 132k"
+              "title": "Llama 3.1 8B 128k"
             },
             {
               "value": "llama3-70b-8192",
-              "title": "Llama3 70B 8k"
+              "title": "Llama 3 70B 8k"
             },
             {
               "value": "llama3-8b-8192",
-              "title": "Llama3 8B 8k"
+              "title": "Llama 3 8B 8k"
             },
             {
               "value": "mixtral-8x7b-32768",
@@ -871,23 +927,27 @@
       "description": "LLM model to use for all your commands.",
       "type": "dropdown",
       "required": true,
-      "default": "llama3-70b-8192",
+      "default": "llama-3.3-70b-versatile",
       "data": [
         {
-          "value": "llama-3.1-70b-versatile",
-          "title": "Llama3.1 70B 132k"
+          "value": "llama-3.3-70b-versatile",
+          "title": "Llama 3.3 70B 128k"
+        },
+        {
+          "value": "llama-3.3-70b-specdec",
+          "title": "Llama 3.3 70B SpecDec 8k"
         },
         {
           "value": "llama-3.1-8b-instant",
-          "title": "Llama3.1 8B 132k"
+          "title": "Llama 3.1 8B 128k"
         },
         {
           "value": "llama3-70b-8192",
-          "title": "Llama3 70B 8k"
+          "title": "Llama 3 70B 8k"
         },
         {
           "value": "llama3-8b-8192",
-          "title": "Llama3 8B 8k"
+          "title": "Llama 3 8B 8k"
         },
         {
           "value": "mixtral-8x7b-32768",

--- a/extensions/groq/src/hook/utils.ts
+++ b/extensions/groq/src/hook/utils.ts
@@ -3,8 +3,7 @@ import { encode } from "gpt-tokenizer";
 export const allModels = [
   { name: "Follow global model", id: "global" },
   { name: "Llama3.1 8B 132k", id: "llama-3.1-8b-instant" },
-  { name: "Llama3.1 70B 132k", id: "llama-3.1-70b-versatile" },
-  { name: "Llama3.3 70B Versatile", id: "llama-3.3-70b-versatile" }, 
+  { name: "Llama3.3 70B 132k", id: "llama-3.3-70b-versatile" },
   { name: "Llama3 8B 8k", id: "llama3-8b-8192" },
   { name: "Llama3 70B 8k", id: "llama3-70b-8192" },
   { name: "Mixtral 8x7B 32k", id: "mixtral-8x7b-32768" },
@@ -34,7 +33,6 @@ export function estimatePrice(prompt_token: number, output_token: number, model:
       price = ((prompt_token * 0.24) / 1_000_000 + (output_token * 0.24) / 1_000_000) * 100;
       break;
     case "llama3-70b-8192":
-    case "llama-3.1-70b-versatile":
     case "llama-3.3-70b-versatile":
       price = ((prompt_token * 0.59) / 1_000_000 + (output_token * 0.79) / 1_000_000) * 100;
       break;

--- a/extensions/groq/src/hook/utils.ts
+++ b/extensions/groq/src/hook/utils.ts
@@ -2,10 +2,11 @@ import { encode } from "gpt-tokenizer";
 
 export const allModels = [
   { name: "Follow global model", id: "global" },
-  { name: "Llama3.1 8B 132k", id: "llama-3.1-8b-instant" },
-  { name: "Llama3.3 70B 132k", id: "llama-3.3-70b-versatile" },
-  { name: "Llama3 8B 8k", id: "llama3-8b-8192" },
-  { name: "Llama3 70B 8k", id: "llama3-70b-8192" },
+  { name: "Llama 3.1 8B 128k", id: "llama-3.1-8b-instant" },
+  { name: "Llama 3.3 70B 128k", id: "llama-3.3-70b-versatile" },
+  { name: "Llama 3.3 70B SpecDec 8k", id: "llama-3.3-70b-specdec" },
+  { name: "Llama 3 8B 8k", id: "llama3-8b-8192" },
+  { name: "Llama 3 70B 8k", id: "llama3-70b-8192" },
   { name: "Mixtral 8x7B 32k", id: "mixtral-8x7b-32768" },
   { name: "Gemma 7B 8k", id: "gemma-7b-it" },
   { name: "Gemma2 9B 8k", id: "gemma2-9b-it" },
@@ -35,6 +36,9 @@ export function estimatePrice(prompt_token: number, output_token: number, model:
     case "llama3-70b-8192":
     case "llama-3.3-70b-versatile":
       price = ((prompt_token * 0.59) / 1_000_000 + (output_token * 0.79) / 1_000_000) * 100;
+      break;
+    case "llama-3.3-70b-specdec":
+      price = ((prompt_token * 0.59) / 1_000_000 + (output_token * 0.99) / 1_000_000) * 100;
       break;
     case "llama3-8b-8192":
     case "llama-3.1-8b-instant":


### PR DESCRIPTION
### New Models and Updates:

* [`extensions/groq/CHANGELOG.md`](diffhunk://#diff-b43f93f869c5e6384a255c0ba10dd106b9bc7b9192356f6dc7fdeeb0d9fe80b6R3-R6): Added entries for new models `Llama 3.3 70B` and `Llama 3.3 70B SpecDec`.

### Model Identifiers and Titles:

* [`extensions/groq/package.json`](diffhunk://#diff-aaa00842ddfa22c3ebaf0032a931253be2aa6025fbd1e71263d17c50a443decdL34-R43): Updated model identifiers and titles from `Llama 3.1` to `Llama 3.3` and added new entries for `Llama 3.3 70B SpecDec`.

### Pricing Estimation:

* [`extensions/groq/src/hook/utils.ts`](diffhunk://#diff-16d1f0b3e4f68a518b5057edf8c13101522e548da46e8b69f5ab7058a6d243a9L5-R7): Updated the pricing estimation logic to include the new `Llama 3.3` models and their respective costs.